### PR TITLE
Add image style uri

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -39,7 +39,6 @@ module:
   image: 0
   jsonapi: 0
   jsonapi_extras: 0
-  jsonapi_image_styles: 0
   jsonapi_menu_items: 0
   jsonapi_resources: 0
   jsonapi_views: 0

--- a/config/sync/jsonapi_image_styles.settings.yml
+++ b/config/sync/jsonapi_image_styles.settings.yml
@@ -1,6 +1,0 @@
-image_styles:
-  large: large
-  media_library: media_library
-  medium: medium
-  thumbnail: thumbnail
-  geofield_map_default_icon_style: 0

--- a/web/modules/custom/lecapi/lecapi.module
+++ b/web/modules/custom/lecapi/lecapi.module
@@ -6,6 +6,8 @@
  */
 
 use Drupal\Component\Utility\Html;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\lecapi\Ia;
@@ -131,4 +133,26 @@ function lecapi_node_grants(AccountInterface $account, $op) {
   }
 
   return ['lecapi' => $grants];
+}
+
+/**
+ * Implements hook_entity_base_field_info().
+ */
+function lecapi_entity_base_field_info(EntityTypeInterface $entity_type) {
+  $fields = [];
+  $base_table = $entity_type->getBaseTable();
+
+  // Certain classes are just not supported.
+  $original_class = $entity_type->getOriginalClass();
+
+  if (!empty($base_table) && $original_class == 'Drupal\file\Entity\File') {
+    $fields['image_style_uri'] = BaseFieldDefinition::create('lecapi_image_style_uri')
+      ->setLabel(t('Entity image styles'))
+      ->setDescription(t('Image styles of the file entity'))
+      ->setComputed(TRUE)
+      ->setCardinality(1)
+      ->setTranslatable(TRUE);
+  }
+
+  return $fields;
 }

--- a/web/modules/custom/lecapi/src/Plugin/Field/FieldType/ImageStyleNormalizedFieldItem.php
+++ b/web/modules/custom/lecapi/src/Plugin/Field/FieldType/ImageStyleNormalizedFieldItem.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\lecapi\Plugin\Field\FieldType;
+
+use Drupal\Core\Field\FieldItemBase;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\TypedData\DataDefinition;
+
+/**
+ * Plugin implementation of the 'image_style_uri' field type.
+ *
+ * @FieldType(
+ *   id = "lecapi_image_style_uri",
+ *   label = @Translation("Image style uri"),
+ *   description = @Translation("Normalized image style paths"),
+ *   no_ui = TRUE,
+ *   list_class = "\Drupal\lecapi\Plugin\Field\FieldType\ImageStyleNormalizedFieldItemList",
+ * )
+ */
+class ImageStyleNormalizedFieldItem extends FieldItemBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function schema(FieldStorageDefinitionInterface $field_definition) {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function propertyDefinitions(FieldStorageDefinitionInterface $field_definition) {
+    $properties['urls'] = DataDefinition::create('any')
+      ->setLabel(t('URLs'))
+      ->setRequired(TRUE);
+    return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isEmpty() {
+    $value = $this->get('urls')->getValue();
+    return $value === serialize([]);
+  }
+
+}

--- a/web/modules/custom/lecapi/src/Plugin/Field/FieldType/ImageStyleNormalizedFieldItemList.php
+++ b/web/modules/custom/lecapi/src/Plugin/Field/FieldType/ImageStyleNormalizedFieldItemList.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\lecapi\Plugin\Field\FieldType;
+
+use Drupal\Core\Field\FieldItemList;
+use Drupal\Core\TypedData\ComputedItemListTrait;
+use Drupal\file\Entity\File;
+use Drupal\image\Entity\ImageStyle;
+
+/**
+ * Represents the computed image styles for a file entity.
+ */
+class ImageStyleNormalizedFieldItemList extends FieldItemList {
+
+  use ComputedItemListTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function computeValue() {
+    $entity = $this->getEntity();
+    $uri = ($entity instanceof File) ? $entity->getFileUri() : FALSE;
+    $styles = ImageStyle::loadMultiple();
+    $urls = [];
+    foreach ($styles as $name => $style) {
+      if ($style instanceof ImageStyle) {
+        $urls[$name] = $style->buildUrl($uri);
+      }
+    }
+    $this->list[0] = $this->createItem(0, ['urls' => $urls]);
+  }
+
+}


### PR DESCRIPTION
Hi @simesy 
We are not using jsonapi_image_styles module anymore because json data return is not good for front-end @febdao .
I have got idea from jsonapi_image_styles module and return a better json data for @febdao .
Old:
<img width="1369" alt="Screen Shot 2020-12-14 at 10 34 19" src="https://user-images.githubusercontent.com/2858879/102037568-ffa2ae00-3df7-11eb-980c-3305186a5155.png">
New:
<img width="1369" alt="Screen Shot 2020-12-14 at 10 34 34" src="https://user-images.githubusercontent.com/2858879/102037585-08937f80-3df8-11eb-904f-7e270c289a2c.png">
